### PR TITLE
Add compatibility with .fastq (@ char at defline)

### DIFF
--- a/reverse_complement.pl
+++ b/reverse_complement.pl
@@ -8,9 +8,12 @@ open(IN, $filein) or die "Cannot open input_fasta file : $filein";
 open(OUT,">".$fileout);
 while (<IN>) {
     chomp;
-    if(m/^>/||m/^@/){
+    if(m/^>/){
         s/^>//;
         print OUT ">rc".$_,"\n";
+    }elsif(m/^@/){
+        s/^>//;
+        print OUT "\@rc".$_,"\n";
     }
     else{
         my $t=$_;

--- a/reverse_complement.pl
+++ b/reverse_complement.pl
@@ -8,7 +8,7 @@ open(IN, $filein) or die "Cannot open input_fasta file : $filein";
 open(OUT,">".$fileout);
 while (<IN>) {
     chomp;
-    if(m/^>/){
+    if(m/^>/||m/^@/){
         s/^>//;
         print OUT ">rc".$_,"\n";
     }


### PR DESCRIPTION
the fastq starts with an '@' character as opposed to '>' in fasta files.